### PR TITLE
docs: fix copy command on Installation page

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ title: Installation
     ```shell-session
     npm install
     npm run build
-    cp dist/* ../express/static/dist/
+    cp -R dist ../express/static/dist
     ```
 
 3. Navigate to the `express` folder


### PR DESCRIPTION
Given that `express/static/dist` does not initially exist, should the copy command copy the whole directory to there?